### PR TITLE
IOS-3017: Feature/Remove `master` references

### DIFF
--- a/Dangerfile-Lint
+++ b/Dangerfile-Lint
@@ -25,7 +25,7 @@ end
 
 def validate_pull_request
   # TODO: Validate that the right branch is being merged, etc.
-  # if branch_for_base == 'master' && branch_for_head != 'develop'
+  # if branch_for_base == 'main' && branch_for_head != 'develop'
   #   fail ''
   # end
 

--- a/Sources/Libraries/CarbonFramework/Lumberjack.swift
+++ b/Sources/Libraries/CarbonFramework/Lumberjack.swift
@@ -6,7 +6,7 @@ import Foundation
 public typealias LumberjackCompletion = () throws -> Void
 
 // Should we update to use TerminalController for printing colors?
-// https://github.com/apple/swift-tools-support-core/blob/master/Sources/TSCBasic/TerminalController.swift
+// https://github.com/apple/swift-tools-support-core/blob/main/Sources/TSCBasic/TerminalController.swift
 
 public class Lumberjack {
     public static let shared = Lumberjack()


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3017

**Description**
- Updated `master` branch reference in our Danger lint file
- Updated `master` reference in link to Apple's repo, as they've updated their branch name as well